### PR TITLE
convert strategy to enum; cleanup renderer.rs imports; cleanup converter.rs functions

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,13 +1,16 @@
 use opencv::prelude::*;
-
-use crate::error::{Error, Result};
+use crate::error::Result;
 
 pub const CHARS: [char; 11] =
 	[' ', ' ', '.', ':', '!', '+', '*', 'e', '$', '@', '8'];
-pub const ASCII: u8 = 0;
-pub const COLOR_ASCII: u8 = 1;
 
-pub fn convert_frame(frame: &Mat, strategy: u8) -> Result<String> {
+#[derive(Copy, Clone, Debug)]
+pub enum Strategy {
+    Ascii,
+    ColorAscii
+}
+
+pub fn convert_frame(frame: &Mat, strategy: Strategy) -> Result<String> {
 	let mut res = String::default();
 
 	for i in 0..frame.rows() {
@@ -22,41 +25,30 @@ pub fn convert_frame(frame: &Mat, strategy: u8) -> Result<String> {
 	Ok(res)
 }
 
-fn convert_pxl(bgr: opencv::core::Vec3b, strategy: u8) -> Result<String> {
+fn convert_pxl(bgr: opencv::core::Vec3b, strategy: Strategy) -> Result<String> {
 	let b = *bgr.get(0).unwrap();
 	let g = *bgr.get(1).unwrap();
 	let r = *bgr.get(2).unwrap();
 
-	match strategy {
-		ASCII => Ok(to_ascii(r, g, b, strategy)?.to_string()),
-		COLOR_ASCII => Ok(to_color_ascii(r, g, b, strategy)?),
-		_ => Err(Error::from("Invalid strategy code")),
-	}
+    Ok(to_ascii(r, g, b, strategy)?.to_string())
 }
 
 // conversion strategies
-fn to_ascii(r: u8, g: u8, b: u8, strategy: u8) -> Result<char> {
+fn to_ascii(r: u8, g: u8, b: u8, strategy: Strategy) -> Result<char> {
 	let brightness: f32;
 
 	match strategy {
-		ASCII => {
+		Strategy::Ascii => {
 			brightness = 0.2126 * f32::from(r)
 				+ 0.7152 * f32::from(g)
 				+ 0.0722 * f32::from(b);
 		}
-		COLOR_ASCII => {
+		Strategy::ColorAscii => {
 			brightness = 0.267 * f32::from(r)
 				+ 0.642 * f32::from(g)
 				+ 0.091 * f32::from(b);
 		}
-		_ => {
-			return Err(Error::from("Invalid strategy code"));
-		}
 	}
 
 	Ok(CHARS[(10.0 * brightness / 255.0) as usize])
-}
-
-fn to_color_ascii(r: u8, g: u8, b: u8, strategy: u8) -> Result<String> {
-	Ok(to_ascii(r, g, b, strategy)?.to_string())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ pub fn main() {
 
 	let opts = opt::Opt::parse();
 
-	let strategy = converter::ASCII;
+	let strategy = converter::Strategy::Ascii;
 
 	if let Err(e) =
 		renderer::render(&opts.file, opts.output.as_deref(), strategy)


### PR DESCRIPTION
This _should_ work properly, it is able to compile without issue. However, I had issues with opencv (I'm using repl.it) so I couldn't test the full functionality.

In converter.rs, you had redundant match statements as well as redundant functions (to_ascii & to_ascii_color). I removed the redundant parts and simplified the code. Additionally, I was able to remove the error paths from the match statement since matching on an enum in Rust is exhaustive.

Let me know if you have any questions about the changes I made, happy to explain if needed.